### PR TITLE
Correción de número de WhatsApp

### DIFF
--- a/src/components/WhatsAppButton.jsx
+++ b/src/components/WhatsAppButton.jsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 const WhatsAppButton = () => {
   const [showTooltip, setShowTooltip] = useState(false);
-  const whatsappNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER || '+573123456789';
+  const whatsappNumber = process.env.NEXT_PUBLIC_WHATSAPP_NUMBER || '+57123456789';
   const defaultMessage = '¡Hola! Me gustaría obtener más información sobre los servicios de Geanet.';
 
   return (


### PR DESCRIPTION
Se puso un número inexistente para que no hayan errores al oprimir el botón flotante de WhatsApp.
Se espera la información final de la empresa.