### PR TITLE
Update Portal de Pagos URL to geanet.site

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -151,7 +151,7 @@ const Header = () => {
             
             {/* Portal de Pagos Button */}
             <a
-              href="https://geanet.online/pay.php"
+              href="https://geanet.site/pay.php"
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center px-4 py-2 text-sm font-medium text-white bg-primary hover:bg-primary/90 transition-colors duration-200 rounded-md ml-2 shadow-sm hover:shadow-md"
@@ -261,7 +261,7 @@ const Header = () => {
               
               {/* Portal de Pagos Button - Mobile */}
               <a
-                href="https://geanet.online/pay.php"
+                href="https://geanet.site/pay.php"
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={handleMobileMenuClick}


### PR DESCRIPTION
### Motivation
- Actualizar el enlace del botón "Portal de Pagos" para que apunte a la nueva pasarela en `https://geanet.site/pay.php`.

### Description
- Reemplazado el `href` en dos ubicaciones dentro de `src/components/Header.jsx` (navegación de escritorio y botón del menú móvil) para usar `https://geanet.site/pay.php` en lugar de `https://geanet.online/pay.php`.

### Testing
- Verificado con `git diff -- src/components/Header.jsx` y `git status --short` que sólo se modificaron esas dos referencias y que los cambios están listos para revisión.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc17826f9c832f92982ca4fa3928d4)